### PR TITLE
TCC: allow builds from git

### DIFF
--- a/TCC/conanfile.py
+++ b/TCC/conanfile.py
@@ -3,7 +3,8 @@ import os
 
 class TccConan(ConanFile):
     name = "tcc"
-    version = "0.9.27"
+    revision = "62c30a4a"
+    version = "0.9.27+%s" % revision if revision else "0.9.27"
     license = "GNU Lesser General Public License"
     author = "Eyck Jentzsch <eyck@minres.com>"
     url = "https://github.com/Minres/conan-recipes/tree/master/TCC"
@@ -11,17 +12,24 @@ class TccConan(ConanFile):
     topics = ("compiler", "c")
     settings = "os", "compiler", "build_type", "arch"
     default_options = {}
-
     source_tar = "http://download.savannah.gnu.org/releases/tinycc/tcc-%s.tar.bz2" % version
+    git_repo = "git://repo.or.cz/tinycc.git"
     #generators = "cmake"
     sub_folder = "tcc-%s" % version
     exports_sources = "tcc-%s/*" % version
 
     def source(self):
-        self.output.info("Downloading %s" %self.source_tar)
-        tools.download(self.source_tar, "tcc.tar.bz2")
-        tools.unzip("tcc.tar.bz2")
-        os.remove("tcc.tar.bz2")
+        if self.revsion:
+            git = tools.Git(folder=self.sub_folder)
+            if not os.path.exists(self.sub_folder):
+                git.clone(self.git_repo)
+                git.pull()
+                git.checkout(self.revision)
+        else:
+            self.output.info("Downloading %s" %self.source_tar)
+            tools.download(self.source_tar, "tcc.tar.bz2")
+            tools.unzip("tcc.tar.bz2")
+            os.remove("tcc.tar.bz2")
 
     def configure(self):
         del self.settings.compiler.libcxx

--- a/TCC/conanfile.py
+++ b/TCC/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 import os
+import shutil
 
 class TccConan(ConanFile):
     name = "tcc"
@@ -19,14 +20,15 @@ class TccConan(ConanFile):
     exports_sources = "tcc-%s/*" % version
 
     def source(self):
-        if self.revsion:
+        if self.revision:
+            self.output.info("Cloning from %s" % self.git_repo)
             git = tools.Git(folder=self.sub_folder)
-            if not os.path.exists(self.sub_folder):
-                git.clone(self.git_repo)
-                git.pull()
-                git.checkout(self.revision)
+            if os.path.exists(self.sub_folder):
+                shutil.rmtree(self.sub_folder) 
+            git.clone(self.git_repo)
+            git.checkout(self.revision)
         else:
-            self.output.info("Downloading %s" %self.source_tar)
+            self.output.info("Downloading %s" % self.source_tar)
             tools.download(self.source_tar, "tcc.tar.bz2")
             tools.unzip("tcc.tar.bz2")
             os.remove("tcc.tar.bz2")


### PR DESCRIPTION
Tiny Code Generator is not buildable with glibc versions >=2.34:

```
../tcc -c bcheck.c -o bcheck.o -B..
bcheck.c:738: error: '__malloc_hook' undeclared
make[1]: *** [Makefile:64: bcheck.o] Error 1
make[1]: Leaving directory '/local/gerum/speech_recognition/external/hannah-tvm/tmp/TGC-VP/build/conan-recipes/TCC/tcc-0.9.27/lib'
```

This is due to the deprecation of  __malloc_hook: https://abi-laboratory.pro/index.php?view=changelog&l=glibc&v=2.34

This patch allows building tcc from upstream git, the used git revision (62c30a4a) is the same as the one used in Ubuntu 22.04 LTS. 
